### PR TITLE
Added compact folds, to hide items like workflowy.

### DIFF
--- a/ftplugin/workflowish.vim
+++ b/ftplugin/workflowish.vim
@@ -1,8 +1,49 @@
 setlocal foldlevel=1
 setlocal foldenable
-setlocal foldmethod=indent
+setlocal sw=2 sts=2
+setlocal expandtab
+setlocal foldtext=WorkflowishFoldText()
+setlocal foldmethod=expr
+setlocal foldexpr=WorkflowishCompactFoldLevel(v:lnum)
 
 setlocal autoindent
+
+" unicode length, from https://github.com/gregsexton/gitv/pull/14
+if exists("*strwidth")
+  "introduced in Vim 7.3
+  fu! s:StringWidth(string)
+    return strwidth(a:string)
+  endfu
+else
+  fu! s:StringWidth(string)
+    return len(split(a:string,'\zs'))
+  endfu
+end
+
+" This feature hides all nested lines under the main one, like workflowy.
+function! WorkflowishCompactFoldLevel(lnum)
+  " TODO: check why vspec can't handle options like &shiftwidth instead of
+  " hardcoded 2
+  let this_indent = indent(a:lnum) / 2
+  let next_indent = indent(a:lnum + 1) / 2
+
+  if next_indent > this_indent
+    return '>' . next_indent
+  else
+    return this_indent
+  endif
+endfunction
+
+
+function! WorkflowishFoldText()
+  let lines = v:foldend - v:foldstart
+  let firstline = getline(v:foldstart)
+  let textend = '|' . lines . '| '
+  let nucolwidth = &fdc + &number*&numberwidth
+  let window_width = winwidth(0) - nucolwidth - 2
+
+  return firstline . repeat(" ", window_width-s:StringWidth(firstline.textend)) . textend
+endfunction
 
 function! workflowish#convert_from_workflowy()
   " Replace all - with *

--- a/t/compact_folds.vim
+++ b/t/compact_folds.vim
@@ -1,0 +1,46 @@
+runtime! ftplugin/workflowish.vim
+
+describe 'compact folds'
+
+  function! s:before()
+    new
+    setfiletype=workflowish
+  endfunction
+
+  function! s:after()
+    close!
+  endfunction
+
+  it 'should set the header-line to startlevel of its children'
+    call s:before()
+
+    execute 'normal' 'i' . join([
+    \	'* Project1',
+    \	'  * check Google Tasks',
+    \	'  * boom',
+    \	'    * bam #bam',
+    \	'    * @lol',
+    \	'* PANCAKES',
+    \	'  \ here are some notes',
+    \	'  * delicious! #yeah! @data',
+    \	'  - this item is done',
+    \	'  * this one still needs doing',
+    \	'    \ notes for this todo',
+    \ ], "\<Return>")
+
+    Expect WorkflowishCompactFoldLevel(1)  ==# '>1'
+    Expect WorkflowishCompactFoldLevel(2)  ==# 1
+    Expect WorkflowishCompactFoldLevel(3)  ==# '>2'
+    Expect WorkflowishCompactFoldLevel(4)  ==# 2
+    Expect WorkflowishCompactFoldLevel(5)  ==# 2
+    Expect WorkflowishCompactFoldLevel(6)  ==# '>1'
+    Expect WorkflowishCompactFoldLevel(7)  ==# 1
+    Expect WorkflowishCompactFoldLevel(8)  ==# 1
+    Expect WorkflowishCompactFoldLevel(9)  ==# 1
+    Expect WorkflowishCompactFoldLevel(10) ==# '>2'
+    Expect WorkflowishCompactFoldLevel(11) ==# 2
+
+    call s:after()
+  end
+
+end


### PR DESCRIPTION
image, row3 [Imgur](http://i.imgur.com/c0hee.png)

I'm a bit sad about missing syntax highlighting for the folds, but haven't found any workaround yet. Tried to patch vim but i don't understand that code well enough yet.

---

Parent item is used to hide the default foldtext, therefore it can't be
syntax highlighted or edited in folded mode. Added unicode length helper
and tests.
