### PR TITLE
add memo about 'za' and other folding commands

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -42,6 +42,7 @@ By defining a simple syntax in Vim and using brilliant [folding capabilities](ht
 - folding and a `zoom/focus` mode
   - `zq` to focus on current item / toggle off
   - `zp` move focus to parent item
+  - `za` toggles folding. See [Vim wiki: Folding](http://vim.wikia.com/wiki/Folding#Opening_and_closing_folds)
 - notes (just add `\` in the beginning of the line to start a comment)
 - [vimgrep](http://vimdoc.sourceforge.net/htmldoc/quickfix.html#:vimgrep) for filtering lines
 - todos:


### PR DESCRIPTION
add memo/obvious rec for 'za', useful for someone like me
who hasn't used folding much in vim
but is using workflowish every day
and opens README to remember commands
until committed to memory :)

also threw in a link to the exact part of the Vim wiki that tells you all the folding commands.